### PR TITLE
Waymark Icons Fix

### DIFF
--- a/Compass/CompassImGui.cs
+++ b/Compass/CompassImGui.cs
@@ -539,6 +539,7 @@ namespace Compass
                             case 060932: // Waymark 2
                             case 060933: // Waymark 3
                             case 063904: // Waymark 4
+                            case 060934: // FATE EXP Bonus Icon
                                 if (mapIconComponentNode->AtkResNode.Rotation == 0)
                                     // => The current quest marker is inside the mask and should be
                                     // treated as a map point

--- a/Compass/CompassImGui.cs
+++ b/Compass/CompassImGui.cs
@@ -538,7 +538,7 @@ namespace Compass
                             case 060931: // Waymark 1
                             case 060932: // Waymark 2
                             case 060933: // Waymark 3
-                            case 060934: // Waymark 4
+                            case 063904: // Waymark 4
                                 if (mapIconComponentNode->AtkResNode.Rotation == 0)
                                     // => The current quest marker is inside the mask and should be
                                     // treated as a map point

--- a/Compass/CompassImGui.cs
+++ b/Compass/CompassImGui.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -531,6 +531,14 @@ namespace Compass
                             case 060455: // Fishing Icon 
                             case 060465: // Fishing Icon 2 
                             case 060466: // Fishing Icon 3
+                            case 060474: // Waymark A
+                            case 060475: // Waymark B
+                            case 060476: // Waymark C
+                            case 060936: // Waymark D
+                            case 060931: // Waymark 1
+                            case 060932: // Waymark 2
+                            case 060933: // Waymark 3
+                            case 060934: // Waymark 4
                                 if (mapIconComponentNode->AtkResNode.Rotation == 0)
                                     // => The current quest marker is inside the mask and should be
                                     // treated as a map point


### PR DESCRIPTION
Prevents Waymark Icons from getting "attached" to the N (North) Icon when out of range and instead are placed properly with an arrow above them like the Flag Icon. Simple case fix with IDs for those icons.

EDIT:

I considered it being easier this way, via a Github Request.