### PR TITLE
The Hunt Mob Marker Fix

### DIFF
--- a/Compass/Data/Constant.cs
+++ b/Compass/Data/Constant.cs
@@ -99,7 +99,7 @@ internal static class Constant {
         ("DoH/DoL Guild Symbols", new uint[] { 060318, 060321, 060326, 60333, 60334, 60335, 60337, 60345, 60346, 60348, 60351 }),
         ("Chocobo Companion", new uint[] { 060961 }),
         ("Party Members", new uint[] { 060421 }),
-        ("Enemies", new uint[] { 060422 }),
+        ("Enemies", new uint[] { 060004, 060422 }),
         ("Boss Enemy", new uint[] { 060401 }),
         ("Alliance Members", new uint[] { 060358 }),
         ("Letter Waymarks", new uint[] { 060474, 060475, 060476, 060936 }),

--- a/Compass/UI/CompassWindow.cs
+++ b/Compass/UI/CompassWindow.cs
@@ -639,6 +639,7 @@ internal static class CompassWindow
                         case 071026: // Weird Blueish Round Exclamation Mark 2 
                         case 071111: // Weird Round Quest Mark  
                         case 071112: // Weird Round Quest Complete Mark
+                        case 060004: // The Hunt Mob Marker
                         case 060954: // Arrow up for quests
                         case 060955: // Arrow down for quests
                         case 060561: // Red Flag (Custom marker)


### PR DESCRIPTION
This is a small "fix" for the Mob Hunt targets icon. This icon is also used by the "Hunt Buddy" plugin to mark hunt targets on the map.

I sorted it into the Enemies category, but it might fit better elsewhere.