### PR TITLE
chore: Update to API15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.33.0
+
+- chore: Update to API15
+
 ## 1.32.0
 
 - chore: Update to API14 (thanks @ashen-dawn)

--- a/Compass/Compass.csproj
+++ b/Compass/Compass.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Dalamud.NET.Sdk/14.0.1">
+<Project Sdk="Dalamud.NET.Sdk/15.0.0">
 
     <PropertyGroup>
-        <VersionPrefix>1.32.0</VersionPrefix>
+        <VersionPrefix>1.33.0</VersionPrefix>
         <Authors>Chivalrik</Authors>
         <Company>Chivalrik</Company>
         <IsPackable>false</IsPackable>
@@ -40,7 +40,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Update="DalamudPackager" Version="14.0.1"/>
+        <PackageReference Update="DalamudPackager" Version="15.0.0"/>
     </ItemGroup>
 
 </Project>

--- a/Compass/Compass.csproj
+++ b/Compass/Compass.csproj
@@ -39,8 +39,4 @@
         </Compile>
     </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Update="DalamudPackager" Version="15.0.0"/>
-    </ItemGroup>
-
 </Project>

--- a/Compass/packages.lock.json
+++ b/Compass/packages.lock.json
@@ -4,9 +4,9 @@
     "net10.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[14.0.1, )",
-        "resolved": "14.0.1",
-        "contentHash": "y0WWyUE6dhpGdolK3iKgwys05/nZaVf4ZPtIjpLhJBZvHxkkiE23zYRo7K7uqAgoK/QvK5cqF6l3VG5AbgC6KA=="
+        "requested": "[15.0.0, )",
+        "resolved": "15.0.0",
+        "contentHash": "411vwC8/X8Z/sQ2TI6v3SvOn66xFPeOjFn3Zn+h0d3Ox2t1kFm66AhDvmx/qcMwVrR+Hidxj0dadpQ2dgyXMBQ=="
       },
       "DotNet.ReproducibleBuilds": {
         "type": "Direct",


### PR DESCRIPTION
Also updates changelog, and removes the explicit reference to `DalamudPackager` (since they indicate that's no longer required in the Dalamud [release notes](https://dalamud.dev/versions/v15#sdk--packages) and have been asking folks to remove that when opening PRs to update the plugin repository)