### PR TITLE
feat: viewport-relative compass position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.34.0
+
+- feat: Store compass position relative to viewport
+
 ## 1.33.1
 
 - chore: Update to API15 (thanks @ashen-dawn)

--- a/Compass/Compass.cs
+++ b/Compass/Compass.cs
@@ -3,7 +3,9 @@ using System.Linq;
 using System.Numerics;
 using Compass.Data;
 using Compass.UI;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Game.ClientState.Conditions;
+using Dalamud.Interface.Utility;
 using Dalamud.Plugin.Services;
 using FFXIVClientStructs.FFXIV.Client.Game.Control;
 using FFXIVClientStructs.FFXIV.Component.GUI;
@@ -17,6 +19,8 @@ internal class Compass
     private readonly Configuration  _config;
     private          int            _currentUiObjectIndex;
     private          bool           _dirty;
+    private          float          _lastFontGlobalScale;
+    private          Vector2        _lastViewportSize;
 
     private DrawVariables _drawVariables;
 
@@ -64,6 +68,8 @@ internal class Compass
             _dirty = !UpdateCachedVariables();
             return;
         }
+
+        UpdateViewportCache();
 
         switch (_config.Visibility)
         {
@@ -116,12 +122,25 @@ internal class Compass
     {
         if (!UpdateMapPointersCache()) return false;
         _drawVariables = new DrawVariables(_config);
+        _lastViewportSize    = ImGuiHelpers.MainViewport.Size;
+        _lastFontGlobalScale = ImGui.GetIO().FontGlobalScale;
         _uiIdentifiers = _config.ShouldHideOnUiObject
                                 .Where(it => it.disable)
                                 .SelectMany(it => it.getUiObjectIdentifier)
                                 .ToArray();
         _currentUiObjectIndex = 0;
         return true;
+    }
+
+    private void UpdateViewportCache()
+    {
+        var viewportSize    = ImGuiHelpers.MainViewport.Size;
+        var fontGlobalScale = ImGui.GetIO().FontGlobalScale;
+        if (viewportSize == _lastViewportSize && Math.Abs(fontGlobalScale - _lastFontGlobalScale) < float.Epsilon) return;
+
+        _drawVariables      = new DrawVariables(_config);
+        _lastViewportSize   = viewportSize;
+        _lastFontGlobalScale = fontGlobalScale;
     }
 
     // `GetAddonByName` is rather expensive, so we cache the ptr instead of

--- a/Compass/Compass.csproj
+++ b/Compass/Compass.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Dalamud.NET.Sdk/15.0.0">
 
     <PropertyGroup>
-        <VersionPrefix>1.33.1</VersionPrefix>
+        <VersionPrefix>1.34.0</VersionPrefix>
         <Authors>Chivalrik</Authors>
         <Company>Chivalrik</Company>
         <IsPackable>false</IsPackable>

--- a/Compass/Configuration.cs
+++ b/Compass/Configuration.cs
@@ -30,7 +30,9 @@ public class Configuration : IPluginConfiguration
     public float ImGuiBackgroundLineThickness   = 1f;
     public int   ImGuiCompassBackgroundLineOffset;
 
+    // Kept for migration from configs that stored top-left coordinates in pixels.
     public Vector2 ImGuiCompassPosition              = new(835, 515);
+    public Vector2 ImGuiCompassCentrePosition        = new(0.5f, 0.5f);
     public float   ImGuiCompassWidth                 = 250f;
     public float   ImGuiCompassReverseMaskPercentage = 1f;
 
@@ -58,7 +60,7 @@ public class Configuration : IPluginConfiguration
     public              bool HideInCombat;
     [JsonIgnore] public bool FreshInstall;
 
-    public int Version { get; set; } = 1;
+    public int Version { get; set; } = 2;
 }
 
 public class ConfigurationV0 : IPluginConfiguration
@@ -92,6 +94,7 @@ public class ConfigurationV0 : IPluginConfiguration
     public int   ImGuiCompassBackgroundLineOffset;
 
     public Vector2 ImGuiCompassPosition              = new(835, 515);
+    public Vector2 ImGuiCompassCentrePosition        = new(0.5f, 0.5f);
     public float   ImGuiCompassWidth                 = 250f;
     public float   ImGuiCompassReverseMaskPercentage = 1f;
 

--- a/Compass/DalamudPackager.targets
+++ b/Compass/DalamudPackager.targets
@@ -1,6 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project>
-    <Target Name="PackagePlugin" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
+    <Target Name="PackagePluginDebug" AfterTargets="Build" Condition="'$(Configuration)' == 'Debug'">
+        <DalamudPackager
+                ProjectDir="$(ProjectDir)"
+                OutputPath="$(OutputPath)"
+                AssemblyName="$(AssemblyName)"
+                MakeZip="false"
+                VersionComponents="3"
+                Exclude="Compass.pdb;Compass.deps.json"/>
+    </Target>
+
+    <Target Name="PackagePluginRelease" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">
         <DalamudPackager
                 ProjectDir="$(ProjectDir)"
                 OutputPath="$(OutputPath)"

--- a/Compass/Data/DrawVariables.cs
+++ b/Compass/Data/DrawVariables.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Numerics;
 using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Utility;
 
 namespace Compass.Data;
 
@@ -13,6 +14,7 @@ namespace Compass.Data;
 internal struct DrawVariables
 {
     internal readonly Vector2 Centre                 = new(835 + 125f, 515 + 25f);
+    internal readonly Vector2 Position               = new(835, 515);
     internal readonly Vector2 BackgroundPMin         = Vector2.Zero;
     internal readonly Vector2 BackgroundPMax         = Vector2.Zero;
     internal readonly Vector2 BackgroundLinePMin     = Vector2.Zero;
@@ -61,9 +63,12 @@ internal struct DrawVariables
         HalfHeight            = Constant.CompassHeight * 0.5f * HeightScale;
 
         CompassUnit = config.ImGuiCompassWidth / (2f * MathF.PI);
-        Centre =
-            new Vector2(config.ImGuiCompassPosition.X + HalfWidth,
-                config.ImGuiCompassPosition.Y + HalfHeight);
+        var viewportSize = ImGuiHelpers.MainViewport.Size;
+        Centre = new Vector2(
+            Math.Clamp(config.ImGuiCompassCentrePosition.X, 0f, 1f) * viewportSize.X,
+            Math.Clamp(config.ImGuiCompassCentrePosition.Y, 0f, 1f) * viewportSize.Y
+        );
+        Position = Centre - new Vector2(HalfWidth, HalfHeight);
 
         BackgroundPMin = new Vector2(
             Centre.X - 5 - HalfWidth * config.ImGuiCompassReverseMaskPercentage

--- a/Compass/Plugin.cs
+++ b/Compass/Plugin.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Numerics;
 using Compass.Data;
 using Compass.Resources;
 using Compass.UI;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Game.Command;
 using Dalamud.Interface.Utility;
 using Dalamud.Plugin;
@@ -49,6 +51,8 @@ public partial class Plugin : IDalamudPlugin
 
         _clientState.Login  += OnLogin;
         _clientState.Logout += OnLogout;
+        _pluginInterface.UiBuilder.OpenConfigUi += OnOpenConfigUi;
+        _pluginInterface.UiBuilder.OpenMainUi   += OnOpenConfigUi;
 
         _commands.AddHandler(Command, new CommandInfo(CommandHandler)
         {
@@ -63,8 +67,7 @@ public partial class Plugin : IDalamudPlugin
         {
             // NOTE: Centers compass on first install
             PluginLog.Information("Fresh install of Compass; centering compass, drawing modal.");
-            var screenSizeCenterX = (ImGuiHelpers.MainViewport.Size * 0.5f).X;
-            _config.ImGuiCompassPosition    =  _config.ImGuiCompassPosition with { X = screenSizeCenterX - _config.ImGuiCompassWidth * 0.5f };
+            _config.ImGuiCompassCentrePosition =  _config.ImGuiCompassCentrePosition with { X = 0.5f };
             _buildingConfigUi               =  true;
             _config.FreshInstall            =  true;
             _pluginInterface.UiBuilder.Draw += DrawConfigUi;
@@ -76,15 +79,12 @@ public partial class Plugin : IDalamudPlugin
 
     private void OnLogout(int type, int code)
     {
-        _pluginInterface.UiBuilder.OpenConfigUi -= OnOpenConfigUi;
-        _pluginInterface.UiBuilder.Draw         -= DrawConfigUi;
-
+        _pluginInterface.UiBuilder.Draw -= DrawConfigUi;
         _pluginInterface.UiBuilder.Draw -= _compass.Draw;
     }
 
     private void OnLogin()
     {
-        _pluginInterface.UiBuilder.OpenConfigUi += OnOpenConfigUi;
         _compass.UpdateCachedVariables();
         _pluginInterface.UiBuilder.Draw += _compass.Draw;
     }
@@ -140,6 +140,14 @@ public partial class Plugin : IDalamudPlugin
             }
         }
 
+        if (config.Version < 2)
+        {
+            PluginLog.Debug("Migrate configuration to version 2.");
+            MigrateCompassPositionToRelative(config);
+            config.Version = 2;
+            pi.SavePluginConfig(config);
+        }
+
         // NOTE: Technical debt; This array is order-sensitive as it is used in combination with
         //  Configuration.ShouldHideOnUiObjectSerializer. There were problems serializing a Dictionary,
         //  but apart from that I am unsure why _this_ was the solution I came up with. Oh well.
@@ -155,6 +163,26 @@ public partial class Plugin : IDalamudPlugin
         }
 
         return config;
+    }
+
+    private static void MigrateCompassPositionToRelative(Configuration config)
+    {
+        var viewportSize = ImGuiHelpers.MainViewport.Size;
+        if (viewportSize.X <= 0f || viewportSize.Y <= 0f)
+        {
+            viewportSize = new Vector2(1920f, 1080f);
+        }
+
+        var centre = config.ImGuiCompassPosition + new Vector2(
+            config.ImGuiCompassWidth * 0.5f,
+            Constant.CompassHeight * 0.5f * ImGui.GetIO().FontGlobalScale
+        );
+
+        config.ImGuiCompassCentrePosition = Vector2.Clamp(
+            new Vector2(centre.X / viewportSize.X, centre.Y / viewportSize.Y),
+            Vector2.Zero,
+            Vector2.One
+        );
     }
 
     #region UI
@@ -212,6 +240,8 @@ public partial class Plugin : IDalamudPlugin
             OnLogout(0, 0);
             _clientState.Login  -= OnLogin;
             _clientState.Logout -= OnLogout;
+            _pluginInterface.UiBuilder.OpenConfigUi -= OnOpenConfigUi;
+            _pluginInterface.UiBuilder.OpenMainUi   -= OnOpenConfigUi;
             _commands.RemoveHandler(Command);
             DebugDtor();
         }

--- a/Compass/PluginDebug.cs
+++ b/Compass/PluginDebug.cs
@@ -17,13 +17,13 @@ public unsafe partial class Plugin
 
     private delegate nuint WriteFileHidDOutputReport(int hidDevice, DualSenseOutputReport* outputReport, ushort reportLength);
 
-    [Signature("E8 ?? ?? ?? ?? 83 7B 18 00 74 55", DetourName = nameof(WriteFileHidDOutputReportDetour))]
+    [Signature("E8 ?? ?? ?? ?? 83 7B 18 00 74 55", DetourName = nameof(WriteFileHidDOutputReportDetour), Fallibility = Fallibility.Fallible)]
     private Hook<WriteFileHidDOutputReport>? _writeFileHidDOutputReportHook { get; init; }
 
-    [Signature("48 8D 1D ?? ?? ?? ?? 4C 8B EA", Offset = 4, UseFlags = SignatureUseFlags.Offset)]
+    [Signature("48 8D 1D ?? ?? ?? ?? 4C 8B EA", Offset = 4, UseFlags = SignatureUseFlags.Offset, Fallibility = Fallibility.Fallible)]
     private int qword_140002258E20 { get; init; }
 
-    [Signature("48 8D 05 ?? ?? ?? ?? 45 33 E4 4C 39 23", Offset = 4, UseFlags = SignatureUseFlags.Offset)]
+    [Signature("48 8D 05 ?? ?? ?? ?? 45 33 E4 4C 39 23", Offset = 4, UseFlags = SignatureUseFlags.Offset, Fallibility = Fallibility.Fallible)]
     private int unk_140002269DE0 { get; init; }
 
     private int _controllerNumber = 1;

--- a/Compass/UI/CompassWindow.cs
+++ b/Compass/UI/CompassWindow.cs
@@ -33,7 +33,7 @@ internal static class CompassWindow
             | ImGuiWindowFlags.NoCollapse
             | ImGuiWindowFlags.NoSavedSettings;
         ImGuiHelpers.ForceNextWindowMainViewport();
-        ImGuiHelpers.SetNextWindowPosRelativeMainViewport(config.ImGuiCompassPosition, ImGuiCond.Always);
+        ImGuiHelpers.SetNextWindowPosRelativeMainViewport(drawVariables.Position, ImGuiCond.Always);
         ImGui.Begin("###ImGuiCompassWindow", flags);
 
         var cosPlayer = MathF.Cos(cameraRotationInRadian);

--- a/Compass/UI/Config.cs
+++ b/Compass/UI/Config.cs
@@ -186,11 +186,16 @@ internal static class Config
             if (ImGui.Button("Center horizontally##ImGui", new Vector2(200f, 25f)))
             {
                 changed = true;
-                var screenSizeCenterX = (ImGuiHelpers.MainViewport.Size * 0.5f).X;
-                config.ImGuiCompassPosition = config.ImGuiCompassPosition with { X = screenSizeCenterX - config.ImGuiCompassWidth * 0.5f };
+                config.ImGuiCompassCentrePosition = config.ImGuiCompassCentrePosition with { X = 0.5f };
             }
 
-            changed |= ImGui.DragFloat2("Position##ImGui", ref config.ImGuiCompassPosition, 1f, float.MinValue, float.MaxValue, "%.f");
+            var positionPercent = config.ImGuiCompassCentrePosition * 100f;
+            if (ImGui.DragFloat2("Center Position (%)##ImGui", ref positionPercent, 0.1f, 0f, 100f, "%.1f"))
+            {
+                changed = true;
+                config.ImGuiCompassCentrePosition = Vector2.Clamp(positionPercent * 0.01f, Vector2.Zero, Vector2.One);
+            }
+
             changed |= ImGui.DragFloat("Width##ImGui", ref config.ImGuiCompassWidth, 1f, 150f, float.MaxValue, "%.f", ImGuiSliderFlags.AlwaysClamp);
             var mask = (int)((1 - config.ImGuiCompassReverseMaskPercentage) * 100);
             changed |= ImGui.SliderInt("Mask###ImGuiCompassMask", ref mask, 0, 90,


### PR DESCRIPTION
## Summary

I regularly change between two different monitors while I'm playing. The monitors have different resolutions. When I swap between resolutions, the compass positioning would be incorrect due to absolute positioning. 

This changes the compass position setting from an absolute pixel-based screen coordinate to a viewport-relative position stored as normalized center coordinates.

Existing configurations are migrated to the new format, and the config UI now edits the compass position as percentages rather than raw pixel values.

## Motivation

Right now the compass position is effectively tied to a specific resolution and monitor setup. If a user changes display resolution, switches between monitors, or moves between setups with different scaling, the saved position can end up far off-screen or otherwise misplaced.

Storing the compass position relative to the current viewport makes the placement resolution-independent, so the compass stays in the same intended part of the screen across different display setups.

## Changes

- store compass position as normalized viewport-relative center coordinates
- migrate existing saved pixel-based positions to the new format
- derive the runtime draw position from the current main viewport size
- update the config UI to edit position as percentages
- refresh cached draw values when viewport size or font scale changes
